### PR TITLE
Fixing minor typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# pngcrush Docker container
+# KindleGen Docker container
 
 [Docker](https://www.docker.io/) container for [KindleGen](http://www.amazon.com/gp/feature.html?docId=1000765211). Has KindleGen set as the entrypoint.
 


### PR DESCRIPTION
I used your helpful container today and happened to notice that the README heading was still named after what I imagine is another container you manage.
