### PR TITLE
Alpine Linux

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,10 +6,7 @@ RUN echo "deb http://archive.ubuntu.com/ubuntu $(lsb_release -sc) main universe"
 RUN apt-get update -y && apt-get install -y wget
 
 # download kindlegen and install it to /usr/bin
-RUN wget http://kindlegen.s3.amazonaws.com/kindlegen_linux_2.6_i386_v2_9.tar.gz -O /tmp/kindlegen_linux_2.6_i386_v2_9.tar.gz
-RUN tar -xzf /tmp/kindlegen_linux_2.6_i386_v2_9.tar.gz -C /tmp
-RUN mv /tmp/kindlegen /usr/bin
-RUN rm -r /tmp/*
+RUN wget http://kindlegen.s3.amazonaws.com/kindlegen_linux_2.6_i386_v2_9.tar.gz -O - | tar -xzf - -C /usr/bin kindlegen
 
 RUN mkdir -p /source
 WORKDIR /source

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,5 @@
-FROM ubuntu
+FROM alpine
 MAINTAINER James Gregory <james@jagregory.com>
-
-# install wget
-RUN echo "deb http://archive.ubuntu.com/ubuntu $(lsb_release -sc) main universe" > /etc/apt/sources.list
-RUN apt-get update -y && apt-get install -y wget
 
 # download kindlegen and install it to /usr/bin
 RUN wget http://kindlegen.s3.amazonaws.com/kindlegen_linux_2.6_i386_v2_9.tar.gz -O - | tar -xzf - -C /usr/bin kindlegen


### PR DESCRIPTION
There are two changes on this branch:
1. The wget and tar commands are combined with a pipe, eliminating the need to use a temporary directory. And it also reduces the number of intermediate images.
2. The base image is changed to alpine, making the resulting image much smaller (37 MB vs 272 MB).
